### PR TITLE
Restructure and shorten the Related Work

### DIFF
--- a/competencies.md
+++ b/competencies.md
@@ -220,91 +220,19 @@ well prepared for common challenges in workplaces outside of academia.
 
 # Related Work {#sec:related-work}
 
-The day-to-day work of many RSEs often includes teaching activities to improve the RSE-related skill set of researchers,
-e.g. in university courses, workshops or one-on-one.
-Therefore, RSEs' work often includes both the use of and the contribution to pertinent teaching materials.
-Various organisations and initiatives provide courses and workshops
-to convey software-related capabilities aimed at the research community.
-Often they make their training material available as Open Educational Resources (OER)
-permitting free access, re-use, adaptation and redistribution.
-In addition to training activities themselves, there are various initiatives that
-are working to better understand the pathways that can be followed to develop specialist
-technical skills. We now highlight a range of relevant work.
+Various initiatives are working to support technical professionals develop their computational skills.
+Particularly related to this work are intiatives that aim to define sets of such skills
+and guide the community with certification programs and training resources.
 
-#### The Carpentries
+#### RSE Competencies Toolkit
 
-The Carpentries [@Carpentries] is a non-profit entity that supports
-a range of open source training materials and international communities
-of volunteer instructors and helpers who run courses around these materials.
-The community also maintains the materials which are based around three core syllabuses --
-Software Carpentry [@CarpentriesSoftware; @Wilson2006; @Wilson2016a],
-Data Carpentry [@CarpentriesData; @Teal2015] and
-Library Carpentry [@CarpentriesLibrary; @Baker2016; @Cope2018].
-
-#### CodeRefinery
-
-CodeRefinery [@CodeRefinery] is a project currently funded by the Nordic
-e-Infrastructure and thus active primarily in the Nordics with the goal
-of teaching essential tools around research software development,
-that are usually skipped in academic education.
-CodeRefinery hosts a set of open source training materials including
-both beginner and intermediate level material and organises multiple
-highly interactive large scale workshops per year.
-
-#### PRACE
-
-The Partnership for Advanced Computing in Europe (PRACE) [@PRACE] offers training
-in the form of massive open online courses (MOOCs), online and on-site training
-events at European HPC facilities (aggregated on various websites, e.g. EuroCC
-Training [@EuroCCTraining]), and white papers. While most training events are
-tailored towards specialist HPC-related RSE skills, several recurring courses covering programming
-languages (C++, FORTRAN, Python) are suitable for a more general RSE audience, as they teach coding
-best practices, modern software design [@LRZModernCpp], project management and
-version control [@LRZIntroCpp].
-
-#### Helmholtz
-
-The Helmholtz association is an example of a research organisation that
-actively shapes the education of their employees.
-As part of its push towards a better RSE environment, the Helmholtz Association
-launched the Helmholtz Federated IT Services platform (HIFIS) [@HIFIS]
-which provides educational material and training amongst other services
-for an audience of over 10,000 scientists in Germany and internationally.
-All of these materials focus on RSE basics to refresh and expand the software
-engineering knowledge for recent graduates or to update the existing
-knowledge of established researchers.
-They are published under OER licenses and can serve as either self-learning
-instructions or form the basis of hands-on training activities.
-
-#### ENCCS
-
-The EuroCC National Competence Center Sweden (ENCCS) [@ENCCS]
-has created a collection of lessons for HPC-oriented RSEs [@ENCCSLessons] and
-has adapted instructor training material from The Carpentries and CodeRefinery
-to create their own instructor manual [@ENCCSInstructorTraining; @ENCCS2022].
-The ENCCS lessons are targeted at individuals who already have general RSE
-skills and are seeking new skills relevant to HPC and software engineering.
-
-#### Education in the German National Research Data Infrastructure (NFDI)
-
-EduTrain (Training & Education) [@EDUTRAIN] is a section of the NFDI [@NFDI].
-Based on the slogan "data literacy from the beginning",
-it contributes to the further development of scientific methods
-and good scientific practice.
-The targeted education also involves research software engineering.
-As described in its concept [@EduTrain2022], there will be a collaboration
-with "The Carpentries" regarding their lesson program.
-Additionally, the approach of how "The Carpentries" are organised will be adopted.
-Moreover, we mention, that several subsections of NFDI engage in domain specific
-educational programs.
-
-#### SURESOFT
-
-SURESOFT [@SURESOFTLink] is a DFG funded project at TU Braunschweig and
-FAU Erlangen-Nürnberg fostering the sustainability of research software
-by helping researchers adopt practices and tools from the software
-engineering community [@SURESOFT2022]. Because tools are not enough on their own but require skill-full execution, the project implements a twofold approach that combines tools and
-infrastructure with education in the form of workshops and hands-on training. While the training material provided by The Carpentries [@Carpentries] is more targeted towards novices, SURESOFT workshops are focused on more advanced software engineering topics like Software Design Principles, Design Patterns, Refactoring, Continuous Integration and Test Driven Development.
+The RSE Competencies Toolkit [@RSECompetenciesToolkit2023] is a community project
+that developed out of a hack day activity at the 2023 edition of the annual
+Software Sustainability Institute Collaborations Workshop [@SSICW23]. The
+toolkit provides a web application that aims to support technical professionals
+in understanding how to develop their skills. It enables them to build a profile
+of their competencies within the system, while it also provides a set of training
+resources that are linked to a competency framework.
 
 #### HPC Certification Forum
 
@@ -315,36 +243,6 @@ and an associated skill tree that provides a classification of HPC competencies.
 This work aims to develop a standardised representation of relevant HPC knowledge
 and skills which can, in turn, lead to structured and recognised sets of skills
 that can underpin the certification process.
-
-#### UNIVERSE-HPC
-
-UNIVERSE-HPC (Understanding and Nurturing an Integrated Vision for
-Education in RSE and HPC) [@UNIVERSEHPC] is a project funded under the UK's
-ExCALIBUR research programme [@EXCALIBUR].
-The project is looking to understand and develop training pathways and
-curricula to support the development of specialist skills in the HPC and
-exascale domains.
-It is aiming to develop learning pathways that represent a variety of
-different routes to gain the necessary skills to become an expert in the
-latest HPC and exascale technologies.
-These routes take into account the challenge presented by the wide range of
-different technical and research backgrounds that future HPC practitioners
-may come from.
-Supporting this requires pathways that offer various different
-skill-development routes that take into account existing skill sets and
-help to fill knowledge gaps.
-To support these pathways, the project is bringing together a range of open
-source training materials and developing new materials where required.
-
-#### RSE Competencies Toolkit
-
-The RSE Competencies Toolkit [@RSECompetenciesToolkit2023] is a community project
-that developed out of a hack day activity at the 2023 edition of the annual
-Software Sustainability Institute Collaborations Workshop [@SSICW23]. The
-toolkit provides a web application that aims to support technical professionals
-in understanding how to develop their skills. It enables them to build a profile
-of their competencies within the system as well as providing a set of training
-resources that are linked to a competency framework.
 
 #### EMBL/EBI Competency Hub
 
@@ -358,6 +256,34 @@ competencies that they relate to. This enables learners to more easily
 find the right training materials in order to support their career
 development journey, helping them to identify what they might want to
 learn and in what order.
+
+#### Training-focused initiatives
+
+Further initiatives implicitly define sets of competencies by providing (open)
+teaching material for selected skills. This is a non-exhaustive list of related
+initiatives, which will be discussed in more detail in a separate publication.
+In some cases, the activities extend beyond training, but they do not focus
+on defining frameworks of competencies.
+
+One prominent example is the Carpentries [@Carpentries], a non-profit entity that supports
+a range of open source training materials and international communities
+of volunteer instructors and helpers who run courses around these materials.
+A similar framework is provided by CodeRefinery [@CodeRefinery], currently
+funded by the Nordic e-Infrastructure,
+as well as SURESOFT [@SURESOFTLink] [@SURESOFT2022], a DFG funded project at TU Braunschweig and
+FAU Erlangen-Nürnberg, targetting more advanced software engineering topics like Software Design Principles, Design Patterns, Refactoring, Continuous Integration and Test Driven Development.
+
+There are also several initiatives focused on training HPC-oriented RSEs,
+such as the Partnership for Advanced Computing in Europe (PRACE) [@PRACE]
+(with material aggregated on various websites, e.g. on EuroCC Training [@EuroCCTraining]),
+UNIVERSE-HPC (Understanding and Nurturing an Integrated Vision for
+Education in RSE and HPC) [@UNIVERSEHPC] (a project funded under the UK's
+ExCALIBUR research programme [@EXCALIBUR]),
+and the EuroCC National Competence Center Sweden (ENCCS) [@ENCCS], which offers
+a collection of lessons for HPC skills [@ENCCSLessons].
+
+Initiatives focused on Germany include EduTrain [@EDUTRAIN] (a section of NFDI [@NFDI]),
+the Helmholtz Federated IT Services platform (HIFIS) [@HIFIS], and the already mentioned SURESOFT [@SURESOFTLink].
 
 # Values {#sec:values}
 

--- a/related-work-training.md
+++ b/related-work-training.md
@@ -1,0 +1,141 @@
+<!-- Extracted from the Competencies paper, as it was focusing too much on training -->
+# Related Work {#sec:related-work}
+
+The day-to-day work of many RSEs often includes teaching activities to improve the RSE-related skill set of researchers,
+e.g. in university courses, workshops or one-on-one.
+Therefore, RSEs' work often includes both the use of and the contribution to pertinent teaching materials.
+Various organisations and initiatives provide courses and workshops
+to convey software-related capabilities aimed at the research community.
+Often they make their training material available as Open Educational Resources (OER)
+permitting free access, re-use, adaptation and redistribution.
+In addition to training activities themselves, there are various initiatives that
+are working to better understand the pathways that can be followed to develop specialist
+technical skills. We now highlight a range of relevant work.
+
+#### The Carpentries
+
+The Carpentries [@Carpentries] is a non-profit entity that supports
+a range of open source training materials and international communities
+of volunteer instructors and helpers who run courses around these materials.
+The community also maintains the materials which are based around three core syllabuses --
+Software Carpentry [@CarpentriesSoftware; @Wilson2006; @Wilson2016a],
+Data Carpentry [@CarpentriesData; @Teal2015] and
+Library Carpentry [@CarpentriesLibrary; @Baker2016; @Cope2018].
+
+#### CodeRefinery
+
+CodeRefinery [@CodeRefinery] is a project currently funded by the Nordic
+e-Infrastructure and thus active primarily in the Nordics with the goal
+of teaching essential tools around research software development,
+that are usually skipped in academic education.
+CodeRefinery hosts a set of open source training materials including
+both beginner and intermediate level material and organises multiple
+highly interactive large scale workshops per year.
+
+#### PRACE
+
+The Partnership for Advanced Computing in Europe (PRACE) [@PRACE] offers training
+in the form of massive open online courses (MOOCs), online and on-site training
+events at European HPC facilities (aggregated on various websites, e.g. EuroCC
+Training [@EuroCCTraining]), and white papers. While most training events are
+tailored towards specialist HPC-related RSE skills, several recurring courses covering programming
+languages (C++, FORTRAN, Python) are suitable for a more general RSE audience, as they teach coding
+best practices, modern software design [@LRZModernCpp], project management and
+version control [@LRZIntroCpp].
+
+#### Helmholtz
+
+The Helmholtz association is an example of a research organisation that
+actively shapes the education of their employees.
+As part of its push towards a better RSE environment, the Helmholtz Association
+launched the Helmholtz Federated IT Services platform (HIFIS) [@HIFIS]
+which provides educational material and training amongst other services
+for an audience of over 10,000 scientists in Germany and internationally.
+All of these materials focus on RSE basics to refresh and expand the software
+engineering knowledge for recent graduates or to update the existing
+knowledge of established researchers.
+They are published under OER licenses and can serve as either self-learning
+instructions or form the basis of hands-on training activities.
+
+#### ENCCS
+
+The EuroCC National Competence Center Sweden (ENCCS) [@ENCCS]
+has created a collection of lessons for HPC-oriented RSEs [@ENCCSLessons] and
+has adapted instructor training material from The Carpentries and CodeRefinery
+to create their own instructor manual [@ENCCSInstructorTraining; @ENCCS2022].
+The ENCCS lessons are targeted at individuals who already have general RSE
+skills and are seeking new skills relevant to HPC and software engineering.
+
+#### Education in the German National Research Data Infrastructure (NFDI)
+
+EduTrain (Training & Education) [@EDUTRAIN] is a section of the NFDI [@NFDI].
+Based on the slogan "data literacy from the beginning",
+it contributes to the further development of scientific methods
+and good scientific practice.
+The targeted education also involves research software engineering.
+As described in its concept [@EduTrain2022], there will be a collaboration
+with "The Carpentries" regarding their lesson program.
+Additionally, the approach of how "The Carpentries" are organised will be adopted.
+Moreover, we mention, that several subsections of NFDI engage in domain specific
+educational programs.
+
+#### SURESOFT
+
+SURESOFT [@SURESOFTLink] is a DFG funded project at TU Braunschweig and
+FAU Erlangen-Nürnberg fostering the sustainability of research software
+by helping researchers adopt practices and tools from the software
+engineering community [@SURESOFT2022]. Because tools are not enough on their own but require skill-full execution, the project implements a twofold approach that combines tools and
+infrastructure with education in the form of workshops and hands-on training. While the training material provided by The Carpentries [@Carpentries] is more targeted towards novices, SURESOFT workshops are focused on more advanced software engineering topics like Software Design Principles, Design Patterns, Refactoring, Continuous Integration and Test Driven Development.
+
+#### HPC Certification Forum
+
+The HPC Certification Forum [@HPCCF] is working towards providing a certification
+process for High Performance Computing skills.
+As part of this process, the group is developing a Competence Standard [@HPCCFCompetencies]
+and an associated skill tree that provides a classification of HPC competencies.
+This work aims to develop a standardised representation of relevant HPC knowledge
+and skills which can, in turn, lead to structured and recognised sets of skills
+that can underpin the certification process.
+
+#### UNIVERSE-HPC
+
+UNIVERSE-HPC (Understanding and Nurturing an Integrated Vision for
+Education in RSE and HPC) [@UNIVERSEHPC] is a project funded under the UK's
+ExCALIBUR research programme [@EXCALIBUR].
+The project is looking to understand and develop training pathways and
+curricula to support the development of specialist skills in the HPC and
+exascale domains.
+It is aiming to develop learning pathways that represent a variety of
+different routes to gain the necessary skills to become an expert in the
+latest HPC and exascale technologies.
+These routes take into account the challenge presented by the wide range of
+different technical and research backgrounds that future HPC practitioners
+may come from.
+Supporting this requires pathways that offer various different
+skill-development routes that take into account existing skill sets and
+help to fill knowledge gaps.
+To support these pathways, the project is bringing together a range of open
+source training materials and developing new materials where required.
+
+#### RSE Competencies Toolkit
+
+The RSE Competencies Toolkit [@RSECompetenciesToolkit2023] is a community project
+that developed out of a hack day activity at the 2023 edition of the annual
+Software Sustainability Institute Collaborations Workshop [@SSICW23]. The
+toolkit provides a web application that aims to support technical professionals
+in understanding how to develop their skills. It enables them to build a profile
+of their competencies within the system as well as providing a set of training
+resources that are linked to a competency framework.
+
+#### EMBL/EBI Competency Hub
+
+The EMBL/EBI Competency Hub [@CompetencyHub] provides a bioinformatics/computational
+biology-focused example of a competency portal. In addition to collecting
+information on a range of competencies that can be browsed within the
+web-based tool, it also provides career profiles for roles
+within the domains that EMBL/EBI focuses on. The hub provides
+access to variety of training resources that are linked to the specific
+competencies that they relate to. This enables learners to more easily
+find the right training materials in order to support their career
+development journey, helping them to identify what they might want to
+learn and in what order.


### PR DESCRIPTION
This PR restructures and shortens the Related Work section, separating the initiatives that are doing something very related to the core of this paper from the initiatives that implicitly do it by providing teaching material on various topics.

For the latter, I condensed the material into three paragraphs:
- Carpentries and related
- HPC-focused
- Germany-focused

All the original material is copied into a separate file, to be used in a separate publication.

I understand that this will be quite a controversial change, so please help me understand if I misplaced some project. The goal is for the paper to become easier to read and the reader to get faster to the point of the paper.

Related to #166.

Current version rendering:

![Screenshot from 2023-11-08 15-53-18](https://github.com/CaptainSifff/paper_teaching-learning-RSE/assets/4943683/9ed8ccb5-33cc-4e51-8570-a4c6b9d1bbc0)

