### PR TITLE
Future Work vs Outlook

### DIFF
--- a/competencies.md
+++ b/competencies.md
@@ -1086,7 +1086,7 @@ publication on the necessary institutions,
 to lay down what is required to best support the continuous need
 for young RSEs to support digital science specifically in Germany.
 
-# Conclusion and Outlook {#sec:conclusion}
+# Conclusion {#sec:conclusion}
 
 This paper started from a community workshop at deRSE23 in Paderborn
 where people working in RSE related fields got together to figure out


### PR DESCRIPTION
Why are there both?

I understand that there was the intention to discuss in detail what future plans are. In that sense, having a "Future Work" section sounds fine.

But then, there is also "Conclusion and Outlook". The "Outlook" part however is, as I see it, only one sentence.

The easiest "fix" would be to rename the `Conclusion and Outlook` into `Conclusion`.