### PR TITLE
Scope software publication skill section to add precision and discuss software citation

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -5587,3 +5587,14 @@ doi = {10.1016/j.emj.2012.03.001},
   urldate = {2023-06-07},
   keywords = {collaboration,community,data science,ethics,handbook,reproducibility,research practices}
 }
+
+@article{smith_SoftwareCitationPrinciples2016,
+  title = {Software Citation Principles},
+  author = {Smith, Arfon M. and Katz, Daniel S. and Niemeyer, Kyle E. and {FORCE11 Software Citation Working Group}},
+  year = {2016},
+  journal = {PeerJ Computer Science},
+  volume = {2},
+  number = {e86},
+  issn = {2376-5992},
+  doi = {10.7717/peerj-cs.86}
+}

--- a/competencies.md
+++ b/competencies.md
@@ -49,7 +49,7 @@ header-includes:
   - \newglossaryentry{NEW}{name={NEW},type={skills},description={Curiosity}}
   - \newglossaryentry{RC}{name={RC},type={skills},description={Understanding the research cycle}}
   - \newglossaryentry{SRU}{name={SRU},type={skills},description={Software re-use}}
-  - \newglossaryentry{SP}{name={SP},type={skills},description={Software publication}}
+  - \newglossaryentry{SP}{name={SP},type={skills},description={Software publication and citation}}
   - \newglossaryentry{DOMREP}{name={DOMREP},type={skills},description={Using domain repositories/directories}}
   - \newglossaryentry{TEAM}{name={TEAM},type={skills},description={Working in a team}}
   - \newglossaryentry{TEACH}{name={TEACH},type={skills},description={Teaching}}
@@ -492,7 +492,7 @@ Beyond that, RSEs will need to properly execute the technicalities of software p
 These include the application of licences and copyright statements,
 understanding and assigning software authorship, crediting contributors,
 maintaining FAIR software metadata and publishing software artefacts.
-Finally, RSEs will need to understand the principles of software citation.
+Finally, RSEs will need to understand the principles of software citation [@smith_SoftwareCitationPrinciples2016].
 This concerns both the potential for reuse of their own work, which demands the provision of complete and correct up-to-date citation metadata for their software,
 as well as their own citation obligations deriving from building on previous work in the form of dependencies.
 

--- a/competencies.md
+++ b/competencies.md
@@ -479,8 +479,13 @@ The second part of \ac{FAIR} software is concerned with publishing new and deriv
 and making them available for re-use by the research community and the general public.
 RSEs need to have a basic understanding of common software licence types, such as "proprietary", "copyleft", and "permissive",
 the compatibility of different common licences and the ramifications for re-using and composing programs.
-Finally, RSEs will need to properly execute the technicalities of software publishing,
-such as applying licences, honouring copyright statements and crediting contributors.
+RSEs will need to properly execute the technicalities of software publishing.
+These include the application of licences and copyright statements,
+understanding and assigning software authorship, crediting contributors,
+maintaining FAIR software metadata and publishing software artefacts.
+Finally, RSEs will need to understand the principles of software citation.
+This concerns both the potential for reuse of their own work, which demands the provision of complete and correct up-to-date citation metadata for their software,
+as well as their own citation obligations deriving from building on previous work in the form of dependencies.
 
 <!-- Using domain repositories/directories -->
 \skillsection{DOMREP}

--- a/competencies.md
+++ b/competencies.md
@@ -9,6 +9,7 @@ author:
   - Gerasimos Chourdakis
   - Simon Christ
   - Jeremy Cohen
+  - Stephan Druskat
   - Fredo Erxleben
   - Jean-Noël Grad
   - Magnus Hagdorn


### PR DESCRIPTION
Based on @annalenalamprecht's [comment](https://github.com/CaptainSifff/paper_teaching-learning-RSE/issues/242#issue-2130957160), I've changed the "Software publication" skill section to include a more precise list of skills for software publication, and discuss software citation as well.

Notes:
- I've added one fundamental reference to the Software Citation Principles paper (IMHO on the same level of fundamentality as SWEBOK, also referenced in a skill section), but removed the more specific reference.
- I've cheekily added myself to the authors list. If this is unwanted, let me know and I'll roll back the last commit.