### PR TITLE
Refer to Diátaxis framework in DOCBB

### DIFF
--- a/.github/spellignore.txt
+++ b/.github/spellignore.txt
@@ -36,6 +36,7 @@ DaLiJe
 de
 deRSE
 DFG
+Diátaxis
 DigComp
 DigCompEdu
 DigCompOrg

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -4035,6 +4035,12 @@ urldate = {2023-05-23}
   publisher = {Public Library of Science ({PLoS})},
 }
 
+@misc{Procida_Diataxis_documentation_framework,
+  author = {Procida, Daniele},
+  title = {{Diátaxis documentation framework}},
+  url = {https://diataxis.fr/}
+}
+
 @Article{Pucker2019,
   author    = {Pucker, Boas and Schilbert, Hanna Marie and Schumacher, Sina Franziska},
   title     = {Integrating Molecular Biology and Bioinformatics Education},

--- a/competencies.md
+++ b/competencies.md
@@ -423,7 +423,7 @@ documentation. Documentation ranges from commenting code blocks to using
 documentation (building) tools.
 It should be written with consideration for the different audiences who may need it 
 depending on their goals and expertise, 
-for example by following the Diátaxis framework @smith_SoftwareCitationPrinciples2016.
+for example by following the Diátaxis framework @Procida_Diataxis_documentation_framework.
 
 <!-- Building distributable libraries -->
 \skillsection{LIBS}

--- a/competencies.md
+++ b/competencies.md
@@ -423,7 +423,7 @@ documentation. Documentation ranges from commenting code blocks to using
 documentation (building) tools.
 It should be written with consideration for the different audiences who may need it 
 depending on their goals and expertise, 
-for example by following the Diátaxis framework @smith_SoftwareCitationPrinciples2016].
+for example by following the Diátaxis framework @smith_SoftwareCitationPrinciples2016.
 
 <!-- Building distributable libraries -->
 \skillsection{LIBS}

--- a/competencies.md
+++ b/competencies.md
@@ -421,6 +421,9 @@ what a piece of software aims to do and how to enable others to use the provided
 is primarily achieved through a "clean" implementation and enhanced by
 documentation. Documentation ranges from commenting code blocks to using
 documentation (building) tools.
+It should be written with consideration for the different audiences who may need it 
+depending on their goals and expertise, 
+for example by following the Diátaxis framework @smith_SoftwareCitationPrinciples2016].
 
 <!-- Building distributable libraries -->
 \skillsection{LIBS}


### PR DESCRIPTION
Resolves #58 by adding a sentence to DOCBB, refering to the Diátaxis framework.

As I mentioned in the linked issue, I would like to add mention of how this relates to some of the other skills. But happy to let that go if others prefer to keep this minimal.