### PR TITLE
add GREENER principles

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -2953,6 +2953,18 @@ urldate={2023-07-27}
   doi       = {10.1016/j.jss.2016.12.016},
 }
 
+@article{Lannelongue2021,
+  author = {Lannelongue, Loïc and Grealey, Jason and Inouye, Michael},
+  title = {Green Algorithms: Quantifying the Carbon Footprint of Computation},
+  journal = {Advanced Science},
+  volume = {8},
+  number = {12},
+  pages = {2100707},
+  keywords = {climate change, computational research, green computing},
+  doi = {10.1002/advs.202100707},
+  year = {2021}
+}
+
 @article{Lannelongue2023,
   title = {{GREENER} principles for environmentally sustainable computational science},
   volume = {3},

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -2953,6 +2953,20 @@ urldate={2023-07-27}
   doi       = {10.1016/j.jss.2016.12.016},
 }
 
+@article{Lannelongue2023,
+  title = {{GREENER} principles for environmentally sustainable computational science},
+  volume = {3},
+  issn = {2662-8457},
+  doi = {10.1038/s43588-023-00461-y},
+  pages = {514--521},
+  number = {6},
+  journaltitle = {Nature Computational Science},
+  shortjournal = {Nat Comput Sci},
+  author = {Lannelongue, Loïc and Aronson, Hans-Erik G. and Bateman, Alex and Birney, Ewan and Caplan, Talia and Juckes, Martin and {McEntyre}, Johanna and Morris, Andrew D. and Reilly, Gerry and Inouye, Michael},
+  date = {2023-06-26},
+  langid = {english},
+}
+
 @Article{Larcombe2017,
   author    = {Larcombe, L. and Hendricusdottir, R. and Attwood, T. K. and Bacall, F. and Beard, N. and Bellis, L. J. and Dunn, W. B. and Hancock, J. M. and Nenadic, A. and Orengo, C. and Overduin, B. and Sansone, S.-A. and Thurston, M. and Viant, M. R. and Winder, C. L. and Goble, C. A. and Ponting, C. P. and Rustici, G.},
   title     = {{ELIXIR}-{UK} role in bioinformatics training at the national level and across {ELIXIR} [version 1; peer review: 4 approved, 1 approved with reservations]},

--- a/competencies.md
+++ b/competencies.md
@@ -658,7 +658,7 @@ The RSE needs to be able to choose appropriate algorithms and techniques
 (\gls{MOD} and \gls{NEW}). Apart from the technical feasibility, this choice is
 also informed by the values outlined in Section @sec:values. For example, the
 RSE needs to be able to estimate resource usage (processing, memory and storage
-consumption). Resource usage has not only a direct financial price tag but also
+consumption, e.g. @Lannelongue2021). Resource usage has not only a direct financial price tag but also
 environmental costs via associated energy consumption.
 
 Software development also includes testing. This task is a manifestation of the

--- a/competencies.md
+++ b/competencies.md
@@ -389,7 +389,9 @@ or configuring a test pipeline to minimise redundancy), and embracing data
 frugality measures (e.g. recognising sufficient resolution when sampling data
 for processing or storage). If past computational solutions were frugal because
 of technological limits, in future they should tend to that by virtue of an
-awareness of what may be adequate.
+awareness of what may be adequate. The \ac{GREENER} principles [@Lannelongue2023] suggest how
+these concerns can be addressed and how research computing can become more environmentally
+sustainable.
 
 ### Emerging challenges
 

--- a/glossary.tex
+++ b/glossary.tex
@@ -62,3 +62,4 @@
 \newacronym{DMP}{DMP}{data management plan}
 \newacronym{EU}{EU}{European Union}
 \newacronym{UK}{UK}{United Kingdom}
+\newacronym{GREENER}{GREENER}{Governance, Responsibility, Estimation, Energy and embodied impacts, New collaborations, Education and Research}


### PR DESCRIPTION
the latest Code for Thought [episode](https://codeforthought.buzzsprout.com/1326658/14838208-en-make-computing-greener-loic-lannelongue) contains a very interesting interview on the GREENER principles. This looks like an excellent starting point for exploring environmentally sustainable research computing. Added sentence and link to paper.