### PR TITLE
Add paragraph about UML in T&R

### DIFF
--- a/competencies.md
+++ b/competencies.md
@@ -653,11 +653,11 @@ knowledge of \gls{TEAM}, and \gls{PM}. Today this means effective use of
 (for oneself and others).
 
 The RSE needs to be able to formulate and discuss structural 
-and behavioural aspects of softare on a more general level than 
+and behavioural aspects of software on a more general level than 
 through the code itself and often even before a first line of code is written. 
 A set of tools and diagrams for effective and standardised communication 
-about software on a meta level is provided by the Unified Modeling Language (UML).
-As a modeling tool it is directly related to \gls{MOD}.
+about software on a meta level is provided by the \acp{UML}.
+As a modelling tool it is directly related to \gls{MOD}.
 Additionally, it can be applied in various stages of the \gls{SWLC} 
 especially in the early stages as a first documentation of the planned
 modular structure to facilitate 

--- a/competencies.md
+++ b/competencies.md
@@ -657,9 +657,9 @@ and behavioural aspects of software on a more general level than
 through the code itself and often even before a first line of code is written. 
 A set of tools and diagrams for effective and standardised communication 
 about software on a meta level is provided by the \acp{UML}.
-As a modelling tool it is directly related to \gls{MOD}.
-Additionally, it can be applied in various stages of the \gls{SWLC} 
-especially in the early stages as a first documentation of the planned
+As a modelling tool, it is directly related to \gls{MOD}.
+Additionally, it can be applied in various stages of the \gls{SWLC}, 
+especially in the early stages, as a first documentation of the planned
 modular structure to facilitate 
 \gls{DOCBB}, \gls{USERS}, \gls{PM} and \gls{TEAM}.
 

--- a/competencies.md
+++ b/competencies.md
@@ -499,7 +499,7 @@ differentiate them from the domain repositories described later.
 \skillsection{MOD}
 
 We define this as a certain quality of analytical thinking that enables an RSE to
-form a mental model of a piece of software in a specific environment (program comprehension).
+form a (mental) model of a piece of software in a specific environment (program comprehension).
 Using that, an RSE should be able to make predictions about a software's behaviour.
 This is a required skill for common tasks such as debugging, profiling, optimising, designing good
 tests, or predicting user interaction.
@@ -651,6 +651,17 @@ technological advancements. Additionally, proper \ac{SE} skills often require
 knowledge of \gls{TEAM}, and \gls{PM}. Today this means effective use of
 \acp{IDE}, \gls{static-analysis} tools, \glspl{design-pattern} and documentation
 (for oneself and others).
+
+The RSE needs to be able to formulate and discuss structural 
+and behavioural aspects of softare on a more general level than 
+through the code itself and often even before a first line of code is written. 
+A set of tools and diagrams for effective and standardised communication 
+about software on a meta level is provided by the Unified Modeling Language (UML).
+As a modeling tool it is directly related to \gls{MOD}.
+Additionally, it can be applied in various stages of the \gls{SWLC} 
+especially in the early stages as a first documentation of the planned
+modular structure to facilitate 
+\gls{DOCBB}, \gls{USERS}, \gls{PM} and \gls{TEAM}.
 
 The RSE needs to be able to choose appropriate algorithms and techniques
 (\gls{MOD} and \gls{NEW}). Apart from the technical feasibility, this choice is

--- a/competencies.md
+++ b/competencies.md
@@ -499,7 +499,7 @@ differentiate them from the domain repositories described later.
 \skillsection{MOD}
 
 We define this as a certain quality of analytical thinking that enables an RSE to
-form a (mental) model of a piece of software in a specific environment (program comprehension).
+form a mental model of a piece of software in a specific environment (program comprehension).
 Using that, an RSE should be able to make predictions about a software's behaviour.
 This is a required skill for common tasks such as debugging, profiling, optimising, designing good
 tests, or predicting user interaction.

--- a/glossary.tex
+++ b/glossary.tex
@@ -43,6 +43,7 @@
 \newacronym[plural=IDEs,firstplural=integrated development environments (IDE)]{IDE}{IDE}{integrated development environment}
 \newacronym[plural=KPIs,firstplural=key performance indicators (KPIs)]{KPI}{KPI}{key performance indicator}
 \newacronym[plural=LLMs,firstplural={large language models (LLMs)}]{LLM}{LLM}{large language model}
+\newacronym{UML}{UML}{Unified Modelling Language}
 \newacronym{HPC}{HPC}{High-Performance Computing}
 \newacronym{HTC}{HTC}{High-Throughput Computing}
 \newacronym{STEM}{STEM}{science, technology, engineering and mathematics}


### PR DESCRIPTION
This fixes #259 by introducing UML as a current tool for modeling and also communicating and documenting software design and structure.

As it also helps with forming an actual formalised model of the software I added brackets around `mental' in MOD.