### PR TITLE
Rework curiosity

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -5685,3 +5685,38 @@ doi = {10.1016/j.emj.2012.03.001},
   issn = {2376-5992},
   doi = {10.7717/peerj-cs.86}
 }
+
+@report{hettrick_survey_2022,
+  author       = {Hettrick, Simon and
+                  Bast, Radovan and
+                  Crouch, Steve and
+                  Wyatt, Claire and
+                  Philippe, Olivier and
+                  Botzki, Alex and
+                  Carver, Jeffrey and
+                  Cosden, Ian and
+                  D'Andrea, Florencia and
+                  Dasgupta, Abhishek and
+                  Godoy, William and
+                  Gonzalez-Beltran, Alejandra and
+                  Hamster, Ulf and
+                  Henwood, Scott and
+                  Holmvall, Patric and
+                  Janosch, Stephan and
+                  Lestang, Thibault and
+                  May, Nick and
+                  Philips, Johan and
+                  Poonawala-Lohani, Nooriyah and
+                  Richmond, Paul and
+                  Sinha, Manodeep and
+                  Thiery, Florian and
+                  Werkhoven, Ben and
+                  Zhang, Qian},
+  title        = {International RSE Survey 2022},
+  month        = aug,
+  year         = 2022,
+  publisher    = {Zenodo},
+  version      = {v0.9.3},
+  doi          = {10.5281/zenodo.7015772},
+  url          = {https://doi.org/10.5281/zenodo.7015772}
+}

--- a/competencies.md
+++ b/competencies.md
@@ -67,7 +67,7 @@ header-includes:
   - \newglossaryentry{SWLC}{name={\SWLC},type={skills},description={Adapting to the software life cycle}}
   - \newglossaryentry{SWREPOS}{name={\SWREPOS},type={skills},description={Use software repositories}}
   - \newglossaryentry{MOD}{name={\MOD},type={skills},description={Software behaviour awareness and analysis}}
-  - \newglossaryentry{NEW}{name={\NEW},type={skills},description={Curiosity}}
+  - \newglossaryentry{NEW}{name={\NEW},type={skills},description={Conducting and leading research}}
   - \newglossaryentry{RC}{name={\RC},type={skills},description={Understanding the research cycle}}
   - \newglossaryentry{SRU}{name={\SRU},type={skills},description={Software re-use}}
   - \newglossaryentry{SP}{name={\SP},type={skills},description={Software publication and citation}}
@@ -511,14 +511,12 @@ and make sure that they do not negatively impact the integrity of their institut
 
 ## Research skills
 
-<!-- Curiosity -->
+<!-- Conducting and leading research -->
 \skillsection{NEW}
 
-RSEs gain their reputation from their effectiveness in interacting with their
-domain peers. Therefore, some curiosity together with a broad overview of the
-research field is required as this enables the RSE to learn new methods and algorithms directly from domain peers.
-Curiosity is also reflected when an RSE is actively
-trying out new tools. Lifelong learning is then no longer just a phrase but
+RSEs are curious and able to conduct research, both on research software engineering, and on their home domain (if any). Senior RSEs are also able to lead research, and many RSEs have a doctorate~\cite{hettrick_survey_2022}. As researchers often standing between research fields, they also gain their reputation from their effectiveness in interacting with researchers from the same or other domains. Therefore, some curiosity together with a broad overview of the
+research field is required, as this enables the RSE to learn new methods and algorithms directly from domain peers. Such curiosity and ability are also reflected when an RSE is actively
+trying out new tools and discovering related literature from adjacent domains. Lifelong learning is then no longer just a phrase but
 becomes a motivation to work.
 
 <!-- Understanding the research cycle -->
@@ -778,7 +776,7 @@ Table: Levels of software eng. skills expected per RSE career stage. {#tbl:comp-
 
 | Competency | Junior RSE                                                                                                                    | Senior RSE                                                                                                                            | Principal RSE                                                                                                                                                                       |
 | ---        | ----------                                                                                                                    | ----------                                                                                                                            | ----------                                                                                                                                                                          |
-| \gls{NEW}        | Should have some curiosity to fit into research teams.                                                                        | Same as junior, but a curiosity to enhance the code base is required.                                                                 | Should have curiosity to know in which direction to steer the project.                                                                                                              |
+| \gls{NEW}        | Should have some curiosity to fit into research teams.                                                                        | Same as junior, but proactivity towards enhancing the code base is required.                                                                 | Should have research insights and a broad view of the research field to steer the project.                                                                                                              |
 | \gls{RC}         | Should be aware of the research life cycle.                                                                                   | Should know the position of the project in the research life cycle.                                                                   | Should know what is necessary for the project to fit into its position in the research life cycle.                                                                                  |
 | \gls{SRU}        | Should be aware of software reusability tools.                                                                                | Should be able to search with software reusability tools.                                                                             | Should be able to effectively search with \gls{SRU} tools and to evaluate and perform the integration of a library into the project.                                                      |
 | \gls{SP}         | Should be aware that software publication needs to consider issues of intellectual property.                                  | Should be able to correctly publish software in simple cases and to identify cases where professional legal advice is needed.         | Same as senior, plus the ability to take the future publication of software into account when initiating and guiding larger software collaboration projects.                        |
@@ -999,7 +997,7 @@ The current situation may differ.
               & Locally-based & RSE-Team based & Locally-based & RSE-Team based &\\\hline
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
     \gls{NEW}&
-    Struggles to learn new methods and skills due to split curiosity
+    Struggles to learn new methods and skills due to split research focus
       between research goal and software project.&
     Gets support from the RSE team to explore new methods and skills,
       make relevant contacts and learn more about the domain.&


### PR DESCRIPTION
In #235, we discussed how "Curiosity" is a nice term, but is not easy to learn or assess. There was a lot of input, and my understanding is that we want to emphasize the ability of an RSE to do research by themselves, something which is already well-understood how to learn (e.g., do a PhD, follow some research-oriented courses, or maybe generally perform lifelong learning). It's been a while since I read the whole paper, but I think we are not really emphasizing this anywhere, so having it as first research skill makes sense.

This PR:

- Renames the section "Curiosity" to "Conducting and leading research", to be explicit.
- Elaborates a bit, especially on the fact that stand between fields, therefore are particularly able to communicate with peers (so, not just researchers, but super-researchers/glue between other researchers).
- Still mentions "curiosity" in the section and in more places, but replaces the term wherever a different term makes sense.
- Refers to [this survey](https://softwaresaved.github.io/international-survey-2022/) that @sdruskat brought to my attention.

Probably still needs some work, but I hope (and think) this is the right direction.

closes #235.
